### PR TITLE
[PAXWARP-45] Ability to pass in changelog to CommandRunner

### DIFF
--- a/pax-warp-core/src/main/java/org/ops4j/pax/warp/core/command/CommandRunner.java
+++ b/pax-warp-core/src/main/java/org/ops4j/pax/warp/core/command/CommandRunner.java
@@ -24,6 +24,8 @@ import java.util.List;
 
 import javax.sql.DataSource;
 
+import org.ops4j.pax.warp.jaxb.gen.ChangeLog;
+
 /**
  * Interface for embedding Pax Warp into client applications via dependency injection.
  *
@@ -156,7 +158,7 @@ public interface CommandRunner {
      *            output stream for change log
      */
     void dumpAll(String jdbcUrl, String username, String password, OutputStream os);
-    
+
     /**
      * Analyzes the structure of the database with the given URL and writes a change log
      * corresponding to the database structure to the given output stream, also including
@@ -168,7 +170,7 @@ public interface CommandRunner {
      *            output stream for change log
      */
     void dumpAll(Connection dbc, OutputStream os);
-    
+
     /**
      * Migrates the database with the given URL by applying the change log from the given input
      * stream.
@@ -205,6 +207,28 @@ public interface CommandRunner {
      *            input stream for change log
      */
     void migrate(Connection dbc, InputStream is);
+
+    /**
+     * Migrates the database with the given connection by applying the given change log.
+     * @param dbc
+     *            JDBC database connection
+     * @param changeLog
+     *            change log
+     */
+    void migrate(Connection dbc, ChangeLog changeLog);
+
+    /**
+     * Migrates the database with the given connection by applying the change log.
+     *
+     * @param dbc
+     *            JDBC database connection
+     * @param changeLog
+     *            change log
+     * @param schema
+     *            database schema which will be created if needed and will be set on the
+     *            given connection for the duration of this command
+     */
+    void migrate(Connection dbc, ChangeLog changeLog, String schema);
 
     /**
      * Migrates the database with the given connection by applying the change log from the given

--- a/pax-warp-core/src/main/java/org/ops4j/pax/warp/core/command/impl/CommandRunnerImpl.java
+++ b/pax-warp-core/src/main/java/org/ops4j/pax/warp/core/command/impl/CommandRunnerImpl.java
@@ -1,19 +1,15 @@
 /*
  * Copyright 2014 Harald Wellmann.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
- * implied.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * See the License for the specific language governing permissions and limitations under the License.
  */
 package org.ops4j.pax.warp.core.command.impl;
 
@@ -36,6 +32,7 @@ import org.ops4j.pax.warp.core.dbms.DbmsProfileSelector;
 import org.ops4j.pax.warp.core.dump.DumpService;
 import org.ops4j.pax.warp.core.update.UpdateService;
 import org.ops4j.pax.warp.exc.WarpException;
+import org.ops4j.pax.warp.jaxb.gen.ChangeLog;
 import org.ops4j.pax.warp.scope.CdiDependent;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -159,6 +156,16 @@ public class CommandRunnerImpl implements CommandRunner {
     @Override
     public void migrate(Connection dbc, InputStream is) {
         updateService.migrate(dbc, is, getDbms(dbc), Optional.empty());
+    }
+
+    @Override
+    public void migrate(Connection dbc, ChangeLog changeLog) {
+        updateService.migrate(dbc, changeLog, getDbms(dbc), Optional.empty());
+    }
+
+    @Override
+    public void migrate(Connection dbc, ChangeLog changeLog, String schema) {
+        updateService.migrate(dbc, changeLog, getDbms(dbc), Optional.of(schema));
     }
 
     @Override

--- a/pax-warp-core/src/main/java/org/ops4j/pax/warp/core/update/UpdateService.java
+++ b/pax-warp-core/src/main/java/org/ops4j/pax/warp/core/update/UpdateService.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.ops4j.pax.warp.core.dbms.DbmsProfile;
+import org.ops4j.pax.warp.jaxb.gen.ChangeLog;
 
 /**
  * Updates a database with information from a change log.
@@ -31,6 +32,26 @@ import org.ops4j.pax.warp.core.dbms.DbmsProfile;
  *
  */
 public interface UpdateService {
+
+    /**
+     * Applies all new change sets from the given change log to the given database. The change set
+     * history metadata table is checked for each change set. If the change set identity is stored
+     * in the table, the actual change set checksum is compared to the change set checksum stored in
+     * the database. If the checksum matches, the change set will be skipped, otherwise, the
+     * migration will be aborted. If the change set identity is not stored, the change set will be
+     * applied, and a record will be added to the history table.
+     *
+     * @param dbc
+     *            JDBC database connection
+     * @param changeLog
+     *            change log
+     * @param dbms
+     *            profile identifying a database management system
+     * @param schema
+     *            Optional database schema. If missing, the default schema will be used.
+     *            If present, the given schema will be used and created if missing.
+     */
+    void migrate(Connection dbc, ChangeLog changeLog, DbmsProfile dbms, Optional<String> schema);
 
     /**
      * Applies all new change sets from the given change log to the given database. The change set


### PR DESCRIPTION
In a multi-tenant setup, to prevent unmarshalling the changeset multiple times, allow passing the changelog to commandrunner.

See https://ops4j1.jira.com/browse/PAXWARP-45